### PR TITLE
fix timing issue with 'look' when an npc dies

### DIFF
--- a/commands/look.js
+++ b/commands/look.js
@@ -59,19 +59,21 @@ exports.command = function (rooms, items, players, npcs, Commands)
 		// show all npcs in the room
 		room.getNpcs().forEach(function (id) {
 			var npc = npcs.get(id);
-			var color = 'cyan';
-			switch (true) {
-				case ((npc.getAttribute('level') - player.getAttribute('level')) > 3):
-					color = 'red';
-					break;
-				case ((npc.getAttribute('level') - player.getAttribute('level')) >= 1):
-					color = 'yellow';
-					break;
-				default:
-					color = 'green'
-					break;
+			if (npc) {
+				var color = 'cyan';
+				switch (true) {
+					case ((npc.getAttribute('level') - player.getAttribute('level')) > 3):
+						color = 'red';
+						break;
+					case ((npc.getAttribute('level') - player.getAttribute('level')) >= 1):
+						color = 'yellow';
+						break;
+					default:
+						color = 'green'
+						break;
+				}
+				player.say('<'+color+'>' + npcs.get(id).getShortDesc(player.getLocale()) + '</'+color+'>');
 			}
-			player.say('<'+color+'>' + npcs.get(id).getShortDesc(player.getLocale()) + '</'+color+'>');
 		});
 
 		player.write('[');


### PR DESCRIPTION
This one is hard to reproduce, but the gist of it is the mud crashed when I used look right when i killed an npc.

Looks like room.getNpcs() had the id for the npc I killed, but when npcs.get(id) was called it could no longer find it.

Just added a check to see if we were able to get an npc.

backtrace:

/Users/Adam/Code/ranvier-adam/commands/look.js:64
                case ((npc.getAttribute('level') - player.getAttribute('level')) > 3):
               ^
TypeError: Cannot call method 'getAttribute' of undefined
    at /Users/Adam/Code/ranvier-adam/commands/look.js:64:16
    at Array.forEach (native)
    at Object.look (/Users/Adam/Code/ranvier-adam/commands/look.js:60:18)
    at TelnetStream.<anonymous> (/Users/Adam/Code/ranvier-adam/src/events.js:243:47)
    at TelnetStream.g (events.js:156:14)
    at TelnetStream.emit (events.js:67:17)
    at emitData (/Users/Adam/Code/ranvier-adam/src/3rdparty/telnet.js:314:14)
    at TelnetStream.processIncomingData (/Users/Adam/Code/ranvier-adam/src/3rdparty/telnet.js:426:5)
    at Socket.<anonymous> (/Users/Adam/Code/ranvier-adam/src/3rdparty/telnet.js:444:12)
    at Socket.emit (events.js:67:17)
