### PR TITLE
Fix path.existsSync deprecation warning

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -27,7 +27,7 @@ var Data = {
 	loadPlayer : function (name)
 	{
 		var playerpath = data_path + 'players/' + name + '.json';
-		if (!path.existsSync(playerpath)) {
+		if (!fs.existsSync(playerpath)) {
 			return false;
 		}
 


### PR DESCRIPTION
Probably should've done this on a separate branch, but it was a one-off kinda thing.
