### PR TITLE
Fix bundle-install for windows

### DIFF
--- a/setup-bundles.js
+++ b/setup-bundles.js
@@ -3,6 +3,7 @@
 
 const cp = require('child_process');
 const fs = require('fs');
+const os = require('os');
 const readline = require('readline');
 
 async function prompt() {
@@ -77,10 +78,13 @@ async function main() {
 
     const fullBundlePath = __dirname + '/' + bundlePath;
 
+    // npm binary based on OS
+    const npmCmd = os.platform().startsWith('win') ? 'npm.cmd' : 'npm';
+
     if (fs.existsSync(fullBundlePath + '/package.json')) {
-      cp.spawnSync('npm', ['install', '--no-audit'], {
+      cp.spawnSync(npmCmd, ['install', '--no-audit'], {
         cwd: fullBundlePath
-      })
+      });
     }
   }
   console.info('Done.');


### PR DESCRIPTION
The `npm install` for installed bundles wasn't working on windows. We have this fix on staging and it was fixing the same issue, please check it on non-windows operating systems