### PR TITLE
Fix "npm run start" for windows users

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "license": "MIT",
   "scripts": {
-    "start": "./ranvier -v --save=10 --respawn=10",
+    "start": "node ./ranvier -v --save=10 --respawn=10",
     "build-docs": "jsdoc -c jsdoc.conf",
     "bundle-install": "node setup-bundles"
   },


### PR DESCRIPTION
Even though I can run just `./ranvier` because I have node in my PATH `npm run start` fails.
Prepending `node` to the npm script fixes this for windows and shouldn't harm other OS

Please let me know if you want this onto staging and not on npmified