### PR TITLE
Return new NPC from Room.spawnNPC

### DIFF
--- a/src/Room.js
+++ b/src/Room.js
@@ -355,6 +355,7 @@ class Room extends Metadatable(EventEmitter) {
    * @param {GameState} state
    * @param {string} entityRef
    * @fires Npc#spawn
+   * @returns {Npc}
    */
   spawnNpc(state, entityRef) {
     Logger.verbose(`\tSPAWN: Adding npc [${entityRef}] to room [${this.title}]`);
@@ -368,6 +369,7 @@ class Room extends Metadatable(EventEmitter) {
      * @event Npc#spawn
      */
     newNpc.emit('spawn');
+    return newNpc;
   }
 
   /**


### PR DESCRIPTION
I found this small tweak to be useful when programmatically spawning NPCs. It allowed me to spawn the NPC in the room and then easily have a reference to the NPC to do other things with (initiate combat, attempt to move them to another room, emit another event on them, etc.)