### PR TITLE
Fixed issue with Wally the vendor

### DIFF
--- a/bundles/ranvier-areas/areas/limbo/npcs.yml
+++ b/bundles/ranvier-areas/areas/limbo/npcs.yml
@@ -102,7 +102,7 @@
         "limbo:potionhealth1":
           cost: 100
           currency: gold
-        "limbo:potionstrength2":
+        "limbo:potionstrength1":
           cost: 150
           currency: gold
         "limbo:bladeofranvier":


### PR DESCRIPTION
Wally the vendor would not list his wares properly using the LIST command.  This is because one of his items was improperly referenced (a typo).