### PR TITLE
Refactor: we now call PlayerManager.tickAll() directly.

### DIFF
--- a/ranvier
+++ b/ranvier
@@ -147,7 +147,7 @@ async function init(restartServer) {
 
     clearInterval(playerTickInterval);
     playerTickInterval = setInterval(() => {
-      GameState.PlayerManager.emit('updateTick');
+      GameState.PlayerManager.tickAll();
     }, Config.get('playerTickFrequency', 100));
   }
 }


### PR DESCRIPTION
Currently, it is doing a `PlayerManager.emit('updateTick')` when it could be doing `PlayerManager.tickAll()`.  That's because the updateTick event ONLY is doing a .tickAll().  
This seems unnecessary and makes it more consistent with how we're calling `AreaManager.tickAll()` and `ItemManager.tickAll()` at set intervals.